### PR TITLE
NPM should contain .js & .d.ts generated files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.idea/
+node_modules/
+typings/
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-gravatar-directive",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Angular2 gravatar directive",
   "main": "src/index.js",
   "typings": "src/index.d.ts",


### PR DESCRIPTION
That's a correction of v2.0.0. Sorry.

I didn't realize that NPM would also ignore `src/*.js` and `src/*.d.ts` files since there was no `.npmignore` present. Hence, it would not work as a CommonJS library.

Please, recheck `.npmignore`, I think `typings/` should not be included but that's not something I'm 100% sure about.

_PS: this time I've tested publishing it on a [repo of my own](https://www.npmjs.com/package/ng2-gravatar-directive-dev) and it works as expected._